### PR TITLE
Fix: Properly handle FormData with requestUrl

### DIFF
--- a/src/infrastructure/api/ApiClient.ts
+++ b/src/infrastructure/api/ApiClient.ts
@@ -115,12 +115,61 @@ export abstract class ApiClient {
 		retryCount = 0
 	): Promise<T> {
 		try {
+			// Handle different body types for requestUrl
+			let body: string | ArrayBuffer | undefined;
+			const headers = options.headers as Record<string, string> || {};
+			
+			if (options.body instanceof FormData) {
+				// Convert FormData to ArrayBuffer for requestUrl compatibility
+				const boundary = `----ObsidianBoundary${Date.now()}`;
+				const chunks: Uint8Array[] = [];
+				const encoder = new TextEncoder();
+				
+				// Build multipart/form-data manually
+				const formData = options.body as FormData;
+				// @ts-ignore - FormData iterator exists at runtime
+				for (const [key, value] of formData) {
+					chunks.push(encoder.encode(`--${boundary}\r\n`));
+					
+					if (value instanceof File) {
+						// Handle file fields
+						chunks.push(encoder.encode(`Content-Disposition: form-data; name="${key}"; filename="${value.name}"\r\n`));
+						chunks.push(encoder.encode(`Content-Type: ${value.type || 'application/octet-stream'}\r\n\r\n`));
+						chunks.push(new Uint8Array(await value.arrayBuffer()));
+						chunks.push(encoder.encode('\r\n'));
+					} else {
+						// Handle text fields
+						chunks.push(encoder.encode(`Content-Disposition: form-data; name="${key}"\r\n\r\n`));
+						chunks.push(encoder.encode(String(value)));
+						chunks.push(encoder.encode('\r\n'));
+					}
+				}
+				
+				// Add final boundary
+				chunks.push(encoder.encode(`--${boundary}--\r\n`));
+				
+				// Combine all chunks into a single ArrayBuffer
+				const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+				const combined = new Uint8Array(totalLength);
+				let offset = 0;
+				for (const chunk of chunks) {
+					combined.set(chunk, offset);
+					offset += chunk.length;
+				}
+				
+				body = combined.buffer;
+				headers['Content-Type'] = `multipart/form-data; boundary=${boundary}`;
+			} else {
+				// For non-FormData requests
+				body = options.body as string | ArrayBuffer;
+			}
+			
 			// Convert RequestInit options to RequestUrlParam format
 			const requestParams = {
 				url: url,
 				method: options.method || 'GET',
-				headers: options.headers as Record<string, string> || {},
-				body: options.body as string | ArrayBuffer,
+				headers: headers,
+				body: body,
 				throw: false // Handle errors manually for consistent behavior
 			};
 

--- a/src/ui/ApiTranscriptionModal.ts
+++ b/src/ui/ApiTranscriptionModal.ts
@@ -134,7 +134,16 @@ export class APITranscriptionModal extends Modal {
 			}
 
 			this.settings.model = option.model;
-			await (this.app as any).plugins.plugins['obsidian-ai-transcriber'].saveSettings();
+
+			// Get plugin instance more safely
+			const pluginId = 'obsidian-ai-transcriber';
+			const plugin = (this.app as any).plugins?.plugins?.[pluginId];
+			if (plugin && typeof plugin.saveSettings === 'function') {
+				await plugin.saveSettings();
+			} else {
+				this.logger.warn('Unable to save settings - plugin instance not found');
+			}
+
 			// Update cost estimate
 			this.displayCostEstimate();
 		});


### PR DESCRIPTION
## Summary
This PR fixes the issues that were supposed to be addressed in PR #15 but were not properly implemented.

## Changes
- ✅ Convert FormData to ArrayBuffer for requestUrl compatibility
- ✅ Implement manual multipart/form-data encoding
- ✅ Fix saveSettings error when changing models in transcription modal
- ✅ Ensure complete removal of fetch API usage

## Technical Details
The original PR #15 was merged but the FormData handling was not correctly implemented. This PR:
1. Manually constructs multipart/form-data as ArrayBuffer since requestUrl doesn't support FormData directly
2. Fixes the saveSettings error by safely accessing the plugin instance with proper null checks

## Testing
- [x] API key verification works correctly
- [x] GPT-4o transcription works without errors
- [x] Model selection in transcription modal saves without errors
- [x] No fetch API calls remain in the codebase

Fixes the incomplete implementation from #15

🤖 Generated with [Claude Code](https://claude.ai/code)